### PR TITLE
Задание 11

### DIFF
--- a/src/main/java/ru/urfu/ConsoleApp.java
+++ b/src/main/java/ru/urfu/ConsoleApp.java
@@ -23,7 +23,8 @@ import java.util.Scanner;
 @SpringBootApplication
 public class ConsoleApp implements CommandLineRunner {
 
-    public static final Path OUTPUT_DIR = Path.of(System.getProperty("user.home"), "lessonSOLID");
+    public static final Path OUTPUT_DIR = Path.of(System.getProperty("user.home"),
+            "IdeaProjects/naumen-architecture");
 
     private final DocumentService documentService;
 

--- a/src/main/java/ru/urfu/ConsoleApp.java
+++ b/src/main/java/ru/urfu/ConsoleApp.java
@@ -1,38 +1,29 @@
 package ru.urfu;
 
-import com.itextpdf.text.DocumentException;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.beans.factory.annotation.Autowired;
-import ru.urfu.document.Document;
-import ru.urfu.document.DocumentService;
-import ru.urfu.utils.PdfExporter;
+import ru.urfu.command.CommandHandlerRegistry;
+import ru.urfu.command.CommandNotFound;
 
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.List;
-import java.util.Optional;
 import java.util.Scanner;
 
 /**
  * Основной класс консольного приложения.
- * Реализует ввод команд и взаимодействие с сервисами.
  */
 @SpringBootApplication
 public class ConsoleApp implements CommandLineRunner {
 
-    public static final Path OUTPUT_DIR = Path.of(System.getProperty("user.home"),
-            "IdeaProjects/naumen-architecture");
+    private final CommandHandlerRegistry commandHandlerRegistry;
+    private final Scanner scanner;
 
-    private final DocumentService documentService;
 
-    private final Scanner scanner = new Scanner(System.in);
-
-    @Autowired
-    public ConsoleApp(DocumentService documentService) {
-        this.documentService = documentService;
+    public ConsoleApp(
+            CommandHandlerRegistry commandHandlerRegistry,
+            Scanner scanner
+    ) {
+        this.commandHandlerRegistry = commandHandlerRegistry;
+        this.scanner = scanner;
     }
 
     /**
@@ -53,112 +44,19 @@ public class ConsoleApp implements CommandLineRunner {
             System.out.print("> ");
             String cmd = scanner.nextLine().trim();
 
-            switch (cmd) {
-                case "create" -> createDocument();
-                case "import" -> importDocument();
-                case "list" -> listDocuments();
-                case "export" -> exportDocument();
-                case "exit" -> {
-                    return;
-                }
-                default -> System.out.println("Неизвестная команда");
-            }
-        }
-    }
-
-    /**
-     * Создаёт документ через ввод данных в консоли.
-     * Сначала пользователь вводит имя, затем — содержимое документа.
-     * Ввод содержимого продолжается до пустой строки.
-     */
-    private void createDocument() {
-        System.out.print("Введите имя документа: ");
-        String name = scanner.nextLine().trim();
-
-        System.out.println("Введите содержимое документа (пустая строка — завершить ввод):");
-
-        StringBuilder content = new StringBuilder();
-        while (true) {
-            String line = scanner.nextLine();
-            if (line.isEmpty()) break; // окончание ввода
-            content.append(line).append(System.lineSeparator());
-        }
-
-        documentService.createDocument(name, content.toString());
-
-        System.out.println("Документ создан и сохранён в памяти.");
-    }
-
-    /**
-     * Выполняет импорт документа.
-     */
-    private void importDocument() {
-        System.out.print("Введите путь к txt файлу: ");
-        String path = scanner.nextLine();
-
-        try {
-            documentService.importTxt(path);
-        } catch (IOException e) {
-            System.out.println("Ошибка импорта: " + e.getMessage());
-        }
-    }
-
-    /**
-     * Выполняет импорт документа.
-     */
-    private void listDocuments() {
-        List<Document> documents = documentService.list();
-        if (documents.isEmpty()) {
-            System.out.println("Документов нет");
-            return;
-        }
-        int i = 0;
-        for (Document doc : documents) {
-            System.out.println(i + ": " + doc.name());
-            i++;
-        }
-    }
-
-    /**
-     * Выполняет импорт документа.
-     */
-    private void exportDocument() {
-        System.out.print("Введите номер документа: ");
-        int index = Integer.parseInt(scanner.nextLine());
-
-        Optional<Document> documentOptional = documentService.getDocument(index);
-        if (documentOptional.isEmpty()) {
-            System.out.println("Нет документа с таким номером.");
-            return;
-        }
-
-        Document document = documentOptional.get();
-
-        System.out.print("Введите формат (txt/pdf): ");
-        String format = scanner.nextLine().trim().toLowerCase();
-
-        try {
-            Files.createDirectories(OUTPUT_DIR);
-        } catch (IOException e) {
-            System.out.println("Ошибка создания директории: " + e);
-            return;
-        }
-
-        Path outputPath = OUTPUT_DIR.resolve(document.name() + "." + format);
-
-        try {
-            switch (format) {
-                case "txt" -> Files.writeString(outputPath, document.content());
-                case "pdf" -> PdfExporter.export(outputPath.toString(), document.content());
-                default -> {
-                    System.out.println("Неверный формат");
-                    return;
-                }
+            if (cmd.equals("exit")) {
+                return;
             }
 
-            System.out.println("Экспорт выполнен: " + outputPath);
-        } catch (IOException | DocumentException e) {
-            System.out.println("Ошибка экспорта: " + e.getMessage());
+            doCommand(cmd);
+        }
+    }
+
+    private void doCommand(String cmd) {
+        try {
+            commandHandlerRegistry.handle(cmd);
+        } catch (CommandNotFound e) {
+            System.out.println("Неизвестная команда");
         }
     }
 }

--- a/src/main/java/ru/urfu/command/CommandHandlerRegistry.java
+++ b/src/main/java/ru/urfu/command/CommandHandlerRegistry.java
@@ -1,0 +1,33 @@
+package ru.urfu.command;
+
+import org.springframework.stereotype.Service;
+import ru.urfu.command.handlers.CommandHandler;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+/**
+ * Класс для регистрации обработчиков команд и их вызова
+ */
+@Service
+public class CommandHandlerRegistry {
+
+    private final Map<String, CommandHandler> handlers;
+
+    public CommandHandlerRegistry(List<CommandHandler> handlers) {
+        this.handlers = handlers.stream()
+                .collect(Collectors.toMap(
+                        CommandHandler::getCommandName,
+                        handler -> handler
+                ));
+    }
+
+    public void handle(String command) {
+        CommandHandler handler = Optional.ofNullable(handlers.get(command))
+                .orElseThrow(() -> new CommandNotFound("Неизвестная команда: " + command));
+
+        handler.handle();
+    }
+}

--- a/src/main/java/ru/urfu/command/CommandHandlerRegistry.java
+++ b/src/main/java/ru/urfu/command/CommandHandlerRegistry.java
@@ -6,6 +6,7 @@ import ru.urfu.command.handlers.CommandHandler;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 /**
@@ -20,7 +21,7 @@ public class CommandHandlerRegistry {
         this.handlers = handlers.stream()
                 .collect(Collectors.toMap(
                         CommandHandler::getCommandName,
-                        handler -> handler
+                        Function.identity()
                 ));
     }
 

--- a/src/main/java/ru/urfu/command/CommandNotFound.java
+++ b/src/main/java/ru/urfu/command/CommandNotFound.java
@@ -1,0 +1,7 @@
+package ru.urfu.command;
+
+public class CommandNotFound extends RuntimeException {
+    public CommandNotFound(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/ru/urfu/command/handlers/CommandHandler.java
+++ b/src/main/java/ru/urfu/command/handlers/CommandHandler.java
@@ -1,0 +1,19 @@
+package ru.urfu.command.handlers;
+
+/**
+ * Обработчик команды
+ */
+public interface CommandHandler {
+
+    /**
+     * Обработка команды
+     */
+    void handle();
+
+    /**
+     * Получить имя команды, которую обрабатывает данный обработчик
+     *
+     * @return имя команды
+     */
+    String getCommandName();
+}

--- a/src/main/java/ru/urfu/command/handlers/CreateHandler.java
+++ b/src/main/java/ru/urfu/command/handlers/CreateHandler.java
@@ -1,0 +1,45 @@
+package ru.urfu.command.handlers;
+
+import org.springframework.stereotype.Component;
+import ru.urfu.document.DocumentService;
+
+import java.util.Scanner;
+
+/**
+ * Обработчик команды create
+ */
+@Component
+public class CreateHandler implements CommandHandler {
+
+    private final Scanner scanner;
+    private final DocumentService documentService;
+
+    public CreateHandler(Scanner scanner, DocumentService documentService) {
+        this.scanner = scanner;
+        this.documentService = documentService;
+    }
+
+    @Override
+    public void handle() {
+        System.out.print("Введите имя документа: ");
+        String name = scanner.nextLine().trim();
+
+        System.out.println("Введите содержимое документа (пустая строка — завершить ввод):");
+
+        StringBuilder content = new StringBuilder();
+        while (true) {
+            String line = scanner.nextLine();
+            if (line.isEmpty()) break;
+            content.append(line).append(System.lineSeparator());
+        }
+
+        documentService.createDocument(name, content.toString());
+
+        System.out.println("Документ создан и сохранён в памяти.");
+    }
+
+    @Override
+    public String getCommandName() {
+        return "create";
+    }
+}

--- a/src/main/java/ru/urfu/command/handlers/ExportHandler.java
+++ b/src/main/java/ru/urfu/command/handlers/ExportHandler.java
@@ -26,7 +26,6 @@ public class ExportHandler implements CommandHandler {
     private final Scanner scanner;
     private final DocumentService documentService;
     private final DocumentExporterRegistry documentExporterRegistry;
-    private final List<DocumentExporter> exporters;
 
     public ExportHandler(
             Scanner scanner,
@@ -37,7 +36,6 @@ public class ExportHandler implements CommandHandler {
         this.scanner = scanner;
         this.documentService = documentService;
         this.documentExporterRegistry = documentExporterRegistry;
-        this.exporters = exporters;
     }
 
     @Override
@@ -84,14 +82,8 @@ public class ExportHandler implements CommandHandler {
         }
     }
 
-    private List<String> getSupportedFormats() {
-        return exporters.stream()
-                .map(DocumentExporter::getFileFormat)
-                .toList();
-    }
-
     private String buildMessage() {
-        return "Введите формат (%s):".formatted(String.join("/", getSupportedFormats()));
+        return "Введите формат (%s):".formatted(String.join("/", documentExporterRegistry.getFormats()));
     }
 
     @Override

--- a/src/main/java/ru/urfu/command/handlers/ExportHandler.java
+++ b/src/main/java/ru/urfu/command/handlers/ExportHandler.java
@@ -1,0 +1,87 @@
+package ru.urfu.command.handlers;
+
+import org.springframework.stereotype.Component;
+import ru.urfu.document.DocumentService;
+import ru.urfu.document.MyDocument;
+import ru.urfu.exporter.DocumentExporter;
+import ru.urfu.exporter.DocumentExporterFactory;
+import ru.urfu.exporter.ExporterNotFound;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Optional;
+import java.util.Scanner;
+
+/**
+ * Обработчик команды export
+ */
+@Component
+public class ExportHandler implements CommandHandler {
+
+    private static final Path OUTPUT_DIR = Path.of(System.getProperty("user.home"),
+            "IdeaProjects/naumen-architecture");
+
+    private final Scanner scanner;
+    private final DocumentService documentService;
+    private final DocumentExporterFactory documentExporterFactory;
+
+    public ExportHandler(
+            Scanner scanner,
+            DocumentService documentService,
+            DocumentExporterFactory documentExporterFactory
+    ) {
+        this.scanner = scanner;
+        this.documentService = documentService;
+        this.documentExporterFactory = documentExporterFactory;
+    }
+
+    @Override
+    public void handle() {
+        System.out.print("Введите номер документа: ");
+        int index = Integer.parseInt(scanner.nextLine());
+
+        Optional<MyDocument> documentOptional = documentService.getDocument(index);
+        if (documentOptional.isEmpty()) {
+            System.out.println("Нет документа с таким номером.");
+            return;
+        }
+
+        MyDocument myDocument = documentOptional.get();
+
+        System.out.print("Введите формат (txt/pdf): ");
+        String format = scanner.nextLine().trim().toLowerCase();
+
+        Path outputPath = buildPath(myDocument.name(), format);
+        if (outputPath == null) {
+            return;
+        }
+
+        doExport(format, outputPath, myDocument);
+    }
+
+    private Path buildPath(String fileName, String format) {
+        try {
+            Files.createDirectories(OUTPUT_DIR);
+            return OUTPUT_DIR.resolve(fileName + "." + format);
+        } catch (IOException e) {
+            System.out.println("Ошибка создания директории: " + e);
+            return null;
+        }
+    }
+
+    private void doExport(String format, Path outputPath, MyDocument myDocument) {
+        try {
+            DocumentExporter exporter = documentExporterFactory.getExporter(format);
+            exporter.export(myDocument, outputPath.toString());
+            System.out.println("Экспорт выполнен: " + outputPath);
+        } catch (ExporterNotFound e) {
+            System.out.println("Неверный формат");
+        }
+    }
+
+    @Override
+    public String getCommandName() {
+        return "export";
+    }
+}

--- a/src/main/java/ru/urfu/command/handlers/ExportHandler.java
+++ b/src/main/java/ru/urfu/command/handlers/ExportHandler.java
@@ -4,12 +4,13 @@ import org.springframework.stereotype.Component;
 import ru.urfu.document.DocumentService;
 import ru.urfu.document.MyDocument;
 import ru.urfu.exporter.DocumentExporter;
-import ru.urfu.exporter.DocumentExporterFactory;
+import ru.urfu.exporter.DocumentExporterRegistry;
 import ru.urfu.exporter.ExporterNotFound;
 
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
 import java.util.Optional;
 import java.util.Scanner;
 
@@ -24,16 +25,19 @@ public class ExportHandler implements CommandHandler {
 
     private final Scanner scanner;
     private final DocumentService documentService;
-    private final DocumentExporterFactory documentExporterFactory;
+    private final DocumentExporterRegistry documentExporterRegistry;
+    private final List<DocumentExporter> exporters;
 
     public ExportHandler(
             Scanner scanner,
             DocumentService documentService,
-            DocumentExporterFactory documentExporterFactory
+            DocumentExporterRegistry documentExporterRegistry,
+            List<DocumentExporter> exporters
     ) {
         this.scanner = scanner;
         this.documentService = documentService;
-        this.documentExporterFactory = documentExporterFactory;
+        this.documentExporterRegistry = documentExporterRegistry;
+        this.exporters = exporters;
     }
 
     @Override
@@ -49,7 +53,7 @@ public class ExportHandler implements CommandHandler {
 
         MyDocument myDocument = documentOptional.get();
 
-        System.out.print("Введите формат (txt/pdf): ");
+        System.out.print(buildMessage());
         String format = scanner.nextLine().trim().toLowerCase();
 
         Path outputPath = buildPath(myDocument.name(), format);
@@ -72,12 +76,22 @@ public class ExportHandler implements CommandHandler {
 
     private void doExport(String format, Path outputPath, MyDocument myDocument) {
         try {
-            DocumentExporter exporter = documentExporterFactory.getExporter(format);
+            DocumentExporter exporter = documentExporterRegistry.getExporter(format);
             exporter.export(myDocument, outputPath.toString());
             System.out.println("Экспорт выполнен: " + outputPath);
         } catch (ExporterNotFound e) {
             System.out.println("Неверный формат");
         }
+    }
+
+    private List<String> getSupportedFormats() {
+        return exporters.stream()
+                .map(DocumentExporter::getFileFormat)
+                .toList();
+    }
+
+    private String buildMessage() {
+        return "Введите формат (%s):".formatted(String.join("/", getSupportedFormats()));
     }
 
     @Override

--- a/src/main/java/ru/urfu/command/handlers/ImportHandler.java
+++ b/src/main/java/ru/urfu/command/handlers/ImportHandler.java
@@ -1,0 +1,40 @@
+package ru.urfu.command.handlers;
+
+import org.springframework.stereotype.Component;
+import ru.urfu.document.DocumentService;
+
+import java.io.IOException;
+import java.util.Scanner;
+
+/**
+ * Обработчик команды import
+ */
+@Component
+public class ImportHandler implements CommandHandler {
+
+    private final Scanner scanner;
+    private final DocumentService documentService;
+
+    public ImportHandler(Scanner scanner, DocumentService documentService) {
+        this.scanner = scanner;
+        this.documentService = documentService;
+    }
+
+    @Override
+    public void handle() {
+        System.out.print("Введите путь к txt файлу: ");
+        String path = scanner.nextLine();
+
+        try {
+            documentService.importTxt(path);
+        } catch (IOException e) {
+            System.out.println("Ошибка импорта: " + e.getMessage());
+        }
+    }
+
+    @Override
+    public String getCommandName() {
+        return "import";
+    }
+
+}

--- a/src/main/java/ru/urfu/command/handlers/ListHandler.java
+++ b/src/main/java/ru/urfu/command/handlers/ListHandler.java
@@ -1,0 +1,42 @@
+package ru.urfu.command.handlers;
+
+import org.springframework.stereotype.Component;
+import ru.urfu.document.DocumentService;
+import ru.urfu.document.MyDocument;
+
+import java.util.List;
+import java.util.Scanner;
+
+/**
+ * Обработчик команды list
+ */
+@Component
+public class ListHandler implements CommandHandler {
+
+    private final Scanner scanner;
+    private final DocumentService documentService;
+
+    public ListHandler(Scanner scanner, DocumentService documentService) {
+        this.scanner = scanner;
+        this.documentService = documentService;
+    }
+
+    @Override
+    public void handle() {
+        List<MyDocument> myDocuments = documentService.list();
+        if (myDocuments.isEmpty()) {
+            System.out.println("Документов нет");
+            return;
+        }
+        int i = 0;
+        for (MyDocument doc : myDocuments) {
+            System.out.println(i + ": " + doc.name());
+            i++;
+        }
+    }
+
+    @Override
+    public String getCommandName() {
+        return "list";
+    }
+}

--- a/src/main/java/ru/urfu/config/CommonConfig.java
+++ b/src/main/java/ru/urfu/config/CommonConfig.java
@@ -1,0 +1,24 @@
+package ru.urfu.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.Scanner;
+
+/**
+ * Конфигурационный класс для общих бинов.
+ */
+@Configuration
+public class CommonConfig {
+
+    /**
+     * Бин для сканера ввода с консоли.
+     *
+     * @return Scanner
+     */
+    @Bean
+    public Scanner cliScanner() {
+        return new Scanner(System.in);
+    }
+
+}

--- a/src/main/java/ru/urfu/document/DocumentService.java
+++ b/src/main/java/ru/urfu/document/DocumentService.java
@@ -14,7 +14,7 @@ import java.util.*;
 @Service
 public class DocumentService {
 
-    private final List<Document> documents = new ArrayList<>();
+    private final List<MyDocument> myDocuments = new ArrayList<>();
 
     /**
      * Импортирует текстовый файл и добавляет его как документ в память.
@@ -30,15 +30,15 @@ public class DocumentService {
         }
 
         String content = Files.readString(path);
-        documents.add(new Document(path.getFileName().toString(), content));
+        myDocuments.add(new MyDocument(path.getFileName().toString(), content));
         System.out.println("Документ импортирован: " + path.getFileName());
     }
 
     /**
      * Возвращает список всех импортированных документов.
      */
-    public List<Document> list() {
-        return Collections.unmodifiableList(documents);
+    public List<MyDocument> list() {
+        return Collections.unmodifiableList(myDocuments);
     }
 
     /**
@@ -47,11 +47,11 @@ public class DocumentService {
      * @param index индекс документа
      * @return Optional с документом или пустой Optional, если индекс неверен
      */
-    public Optional<Document> getDocument(int index) {
-        if (index < 0 || index >= documents.size()) {
+    public Optional<MyDocument> getDocument(int index) {
+        if (index < 0 || index >= myDocuments.size()) {
             return Optional.empty();
         }
-        return Optional.of(documents.get(index));
+        return Optional.of(myDocuments.get(index));
     }
 
     /**
@@ -61,7 +61,7 @@ public class DocumentService {
      * @param content текстовое содержимое документа
      */
     public void createDocument(String name, String content) {
-        documents.add(new Document(name, content));
+        myDocuments.add(new MyDocument(name, content));
     }
 
 }

--- a/src/main/java/ru/urfu/document/MyDocument.java
+++ b/src/main/java/ru/urfu/document/MyDocument.java
@@ -6,6 +6,6 @@ package ru.urfu.document;
  * @param name    Имя
  * @param content текстовое содержимое документа
  */
-public record Document(String name, String content) {
+public record MyDocument(String name, String content) {
 }
 

--- a/src/main/java/ru/urfu/exporter/DocumentExporter.java
+++ b/src/main/java/ru/urfu/exporter/DocumentExporter.java
@@ -1,0 +1,24 @@
+package ru.urfu.exporter;
+
+import ru.urfu.document.MyDocument;
+
+/**
+ * Экспортирует документ в определенный формат файла
+ */
+public interface DocumentExporter {
+    /**
+     * Экспорт документа с сохранением в файловую систему
+     *
+     * @param myDocument   объект {@link MyDocument}
+     * @param pathToSave путь, куда будет сохранен файл
+     */
+    void export(MyDocument myDocument, String pathToSave);
+
+    /**
+     * Получить формат файла, в который экспортирует данная реализация
+     *
+     * @return формат файла. Например pdf, pptx, word
+     */
+    String getFileFormat();
+
+}

--- a/src/main/java/ru/urfu/exporter/DocumentExporterFactory.java
+++ b/src/main/java/ru/urfu/exporter/DocumentExporterFactory.java
@@ -1,0 +1,39 @@
+package ru.urfu.exporter;
+
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+/**
+ * Фабрика экспортеров для документов. Выбирает нужный экспортер в зависимости от типа документа.
+ * Экспортер должен реализовывать интерфейс {@link DocumentExporter}.
+ */
+@Service
+public class DocumentExporterFactory {
+
+    private final Map<String, DocumentExporter> exporters;
+
+    public DocumentExporterFactory(List<DocumentExporter> exporters) {
+        this.exporters = exporters.stream()
+                .collect(Collectors.toMap(
+                        DocumentExporter::getFileFormat,
+                        exporter -> exporter
+                ));
+    }
+
+
+    /**
+     * Получить экспортер по типу документа
+     *
+     * @param type тип документа
+     * @return объект, реализующий интерфейс {@link DocumentExporter}
+     */
+    public DocumentExporter getExporter(String type) {
+        return Optional.ofNullable(exporters.get(type))
+                .orElseThrow(() -> new ExporterNotFound("Неизвестный тип экспортера: " + type));
+    }
+
+}

--- a/src/main/java/ru/urfu/exporter/DocumentExporterRegistry.java
+++ b/src/main/java/ru/urfu/exporter/DocumentExporterRegistry.java
@@ -5,22 +5,23 @@ import org.springframework.stereotype.Service;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 /**
- * Фабрика экспортеров для документов. Выбирает нужный экспортер в зависимости от типа документа.
+ * Хранилище экспортеров для документов. Возвращает нужный экспортер в зависимости от типа документа.
  * Экспортер должен реализовывать интерфейс {@link DocumentExporter}.
  */
 @Service
-public class DocumentExporterFactory {
+public class DocumentExporterRegistry {
 
     private final Map<String, DocumentExporter> exporters;
 
-    public DocumentExporterFactory(List<DocumentExporter> exporters) {
+    public DocumentExporterRegistry(List<DocumentExporter> exporters) {
         this.exporters = exporters.stream()
                 .collect(Collectors.toMap(
                         DocumentExporter::getFileFormat,
-                        exporter -> exporter
+                        Function.identity()
                 ));
     }
 

--- a/src/main/java/ru/urfu/exporter/DocumentExporterRegistry.java
+++ b/src/main/java/ru/urfu/exporter/DocumentExporterRegistry.java
@@ -37,4 +37,13 @@ public class DocumentExporterRegistry {
                 .orElseThrow(() -> new ExporterNotFound("Неизвестный тип экспортера: " + type));
     }
 
+    /**
+     * Получить все доступные форматы для экспорта
+     *
+     * @return список форматов
+     */
+    public List<String> getFormats() {
+        return exporters.keySet().stream().toList();
+    }
+
 }

--- a/src/main/java/ru/urfu/exporter/ExporterNotFound.java
+++ b/src/main/java/ru/urfu/exporter/ExporterNotFound.java
@@ -1,0 +1,7 @@
+package ru.urfu.exporter;
+
+public class ExporterNotFound extends RuntimeException {
+    public ExporterNotFound(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/ru/urfu/exporter/PdfExporter.java
+++ b/src/main/java/ru/urfu/exporter/PdfExporter.java
@@ -1,0 +1,40 @@
+package ru.urfu.exporter;
+
+import com.itextpdf.text.Document;
+import com.itextpdf.text.DocumentException;
+import com.itextpdf.text.Paragraph;
+import com.itextpdf.text.pdf.PdfWriter;
+import org.springframework.stereotype.Component;
+import ru.urfu.document.MyDocument;
+
+import java.io.FileOutputStream;
+import java.io.IOException;
+
+/**
+ * Экспортирует документ в pdf
+ */
+@Component
+public class PdfExporter implements DocumentExporter {
+
+    @Override
+    public void export(MyDocument myDocument, String pathToSave) {
+        try {
+            try (FileOutputStream outputStream = new FileOutputStream(pathToSave)) {
+                Document pdf = new Document();
+                PdfWriter.getInstance(pdf, outputStream);
+
+                pdf.open();
+                pdf.add(new Paragraph(myDocument.content()));
+                pdf.close();
+            }
+        } catch (IOException | DocumentException e) {
+            System.out.println("Ошибка при экспорте документа в pdf: " + e.getMessage());
+        }
+    }
+
+    @Override
+    public String getFileFormat() {
+        return "pdf";
+    }
+
+}

--- a/src/main/java/ru/urfu/exporter/TxtExporter.java
+++ b/src/main/java/ru/urfu/exporter/TxtExporter.java
@@ -1,0 +1,30 @@
+package ru.urfu.exporter;
+
+import org.springframework.stereotype.Component;
+import ru.urfu.document.MyDocument;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/**
+ * Экспортирует документ в .txt
+ */
+@Component
+public class TxtExporter implements DocumentExporter {
+
+    @Override
+    public void export(MyDocument myDocument, String pathToSave) {
+        try {
+            Files.writeString(Path.of(pathToSave), myDocument.content());
+        } catch (IOException e) {
+            System.out.println("Ошибка при экспорте документа в txt: " + e.getMessage());
+        }
+    }
+
+    @Override
+    public String getFileFormat() {
+        return "txt";
+    }
+
+}


### PR DESCRIPTION
## Как добавить новый формат файла для экспорта
1. Реализовать интерфейс `DocumentExporter`
2. Обновить текст сообщения с выбором экспорта здесь https://github.com/yakovlev05/naumen-architecture/blob/e892fa19e06c51e5aea31e5211a5e6e4268744df/src/main/java/ru/urfu/command/handlers/ExportHandler.java#L52

Здесь логичнее было бы добавить enum как для форматов файла, так и для команд. Тогда все форматы и команды были бы видны в одном месте. Подобные сообщения можно было бы строить динамически. Но я не стал так заморачиваться, тем более, что было бы и так два действия (хотя если сообщений с форматами было бы больше, то в enum нужно было бы выносить :100: )

## Что было сделано?
- Вынес все команды в отдельные классы. Сделал общий интерфейс `CommandHandler`, сделал `CommandHandlerRegistry`, который отвечает за вызов нужного обработчика
- Вынес экспортеры в отдельный классы, реализующие интерфейс `DocumentExporter`

## Что можно ещё?
- сделать команды и типы файлов в enum
- отделить логику сохранения, работы со списком документов в `DocumentStorage` (сейчас все вместе в `DocumentService`)